### PR TITLE
Add KUAL extension to start the dashboard

### DIFF
--- a/KUAL/kindle-dash/config.xml
+++ b/KUAL/kindle-dash/config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extension>
+	<information>
+		<name>Kindle dashboard</name>
+		<id>pascalw-kindle-dash</id>
+	</information>
+	<menus>
+		<menu type="json" dynamic="true">menu.json</menu>
+	</menus>
+</extension>

--- a/KUAL/kindle-dash/menu.json
+++ b/KUAL/kindle-dash/menu.json
@@ -1,0 +1,5 @@
+{
+  "items": [
+     {"name": "Kindle Dashboard", "action": "/mnt/us/dashboard/start.sh"}
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ If you're running kindle-dash already and want to update to the latest version f
 4. Modify files in `/mnt/us/dashboard/local` if applicable.
 5. Start dashboard with `/mnt/us/dashboard/start.sh`.  
    Note that the device will go into suspend about 10-15 seconds after you start the dashboard.
+   
+## KUAL
+
+If you're using KUAL you can use simple extension to start this Dashboard
+
+1. Copy folder `kindle-dash` from `KUAL` folder to the kual `extensions` folder. (located in `/mnt/us/extensions`)
 
 ## How this works
 


### PR DESCRIPTION
Because if the kindle battery is drained and the kindle turn off it must be connected to the PC and run dashboard from the ssh again.

So i create simple KUAL extension to run the dashboard directly from the kindle menu/library