### PR TITLE
Kindle PW Touch compatibility

### DIFF
--- a/src/dash.sh
+++ b/src/dash.sh
@@ -27,7 +27,11 @@ init() {
 
   echo "Starting dashboard with $REFRESH_SCHEDULE refresh..."
 
-  /etc/init.d/framework stop
+  if [ -f /etc/init.d/framework ]; then
+    /etc/init.d/framework stop
+  else
+    /etc/init/framework stop
+  fi
   initctl stop webreader >/dev/null 2>&1
   echo powersave >/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
   lipc-set-prop com.lab126.powerd preventScreenSaver 1

--- a/src/local/fetch-dashboard.sh
+++ b/src/local/fetch-dashboard.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env sh
+
+# Url of content to download
+CONTENT="https://raw.githubusercontent.com/pascalw/kindle-dash/master/example/example.png"
+
 # Fetch a new dashboard image, make sure to output it to "$1".
 # For example:
-"$(dirname "$0")/../xh" -d -q -o "$1" get https://raw.githubusercontent.com/pascalw/kindle-dash/master/example/example.png
+# "$(dirname "$0")/../xh" -d -q -o "$1" get $CONTENT
+# xh seems not to be able to load certificates on Kindle PW Touch, and wget has same problem, curl should work everywhere
+curl -o "$1" "$CONTENT"

--- a/src/local/fetch-dashboard.sh
+++ b/src/local/fetch-dashboard.sh
@@ -5,6 +5,8 @@ CONTENT="https://raw.githubusercontent.com/pascalw/kindle-dash/master/example/ex
 
 # Fetch a new dashboard image, make sure to output it to "$1".
 # For example:
-# "$(dirname "$0")/../xh" -d -q -o "$1" get $CONTENT
-# xh seems not to be able to load certificates on Kindle PW Touch, and wget has same problem, curl should work everywhere
-curl -o "$1" "$CONTENT"
+"$(dirname "$0")/../xh" -d -q -o "$1" get $CONTENT
+# xh seems not to be able to load certificates on Kindle PW Touch: fall back to curl in case of error
+if [ $? != 0 ]; then
+  curl -o "$1" "$CONTENT"
+fi


### PR DESCRIPTION
Hello @pascalw , thank you for this useful piece of software.
I found it not working on Kindle PW Touch for two issues:

1. /etc/init.d/ directory is empty. Btw, calling /etc/init/framework stop seems to have the same effect. I placed an IF to retain the original behavior where possible.
2. For some reason, `xh` seems not to work with the certificates contained in Kindle PW Touch: it is unable to read the certificates file:
```
 xh: error: builder error: Could not load PEM file "/etc/ssl/certs/ca-certificates.crt"

Caused by:
    Could not load PEM file "/etc/ssl/certs/ca-certificates.crt"
```
Also wget included in busybox seems not to work, while curl seems to work ok. Curl should be present everywhere, so it should be a safe fallback when xh fails. Feel free to edit the change or suggest edits, if the fix doesn't fit the project code style.

Have a nice day!
Daniele